### PR TITLE
Add option to disable skipping videos

### DIFF
--- a/vlc/MP4Handler.hx
+++ b/vlc/MP4Handler.hx
@@ -12,6 +12,7 @@ class MP4Handler extends VlcBitmap
 {
 	public var readyCallback:Void->Void;
 	public var finishCallback:Void->Void;
+	public var canSkip:Bool = true;
 
 	var pauseMusic:Bool;
 
@@ -42,7 +43,7 @@ class MP4Handler extends VlcBitmap
 
 	function update(e:Event)
 	{
-		if ((FlxG.keys.justPressed.ENTER || FlxG.keys.justPressed.SPACE #if android || FlxG.android.justReleased.BACK #end) && isPlaying)
+		if (canSkip && (FlxG.keys.justPressed.ENTER || FlxG.keys.justPressed.SPACE #if android || FlxG.android.justReleased.BACK #end) && isPlaying)
 			finishVideo();
 
 		if (FlxG.sound.muted || FlxG.sound.volume <= 0)

--- a/vlc/MP4Handler.hx
+++ b/vlc/MP4Handler.hx
@@ -16,7 +16,7 @@ class MP4Handler extends VlcBitmap
 
 	var pauseMusic:Bool;
 
-	public function new(width:Float = 320, height:Float = 240, autoScale:Bool = true, needsUpdate:Bool = true)
+	public function new(width:Float = 320, height:Float = 240, autoScale:Bool = true)
 	{
 		super(width, height, autoScale);
 
@@ -26,10 +26,7 @@ class MP4Handler extends VlcBitmap
 
 		FlxG.addChildBelowMouse(this);
 
-		if (needsUpdate)
-		{
-			FlxG.stage.addEventListener(Event.ENTER_FRAME, update);
-		}
+		FlxG.stage.addEventListener(Event.ENTER_FRAME, update);
 
 		FlxG.signals.focusGained.add(function()
 		{

--- a/vlc/MP4Sprite.hx
+++ b/vlc/MP4Sprite.hx
@@ -17,8 +17,9 @@ class MP4Sprite extends FlxSprite
 	{
 		super(x, y);
 
-		bitmap = new MP4Handler(width, height, autoScale, false);
+		bitmap = new MP4Handler(width, height, autoScale);
 		bitmap.alpha = 0;
+		bitmap.canSkip = false;
 
 		bitmap.readyCallback = function()
 		{


### PR DESCRIPTION
Some games (or FNF mods like DDTO) would want to have the player not being able to skip a video. This PR adds the option to do so, with skipping enabled by default to keep compatibility with existing projects that use hxCodec.

Additionally, this fixes a recent issue with MP4Sprite where changing the HaxeFlixel volume would not change the volume of the playing video.