### PR TITLE
Expose libvlc's setTime

### DIFF
--- a/vlc/bitmap/VlcBitmap.hx
+++ b/vlc/bitmap/VlcBitmap.hx
@@ -198,6 +198,11 @@ class VlcBitmap extends Bitmap
 			return 0;
 	}
 
+	public function setTime(time:Int)
+	{
+		libvlc.setTime(time);
+	}
+
 	public function getTime():Int
 	{
 		if (libvlc != null && initComplete)


### PR DESCRIPTION
This PR adds a setTime function to VlcBitmap, allowing the user to directly set the current time of the video.

I'm unsure if this is what the seek function is supposed to do (or a similar function to it), as it currently doesn't work for me as noted in issue #101. 