### PR TITLE
Fix the video path for Linux

### DIFF
--- a/vlc/VideoHandler.hx
+++ b/vlc/VideoHandler.hx
@@ -59,12 +59,12 @@ class VideoHandler extends VlcBitmap
 	{
 		#if !android
 		var pDir = "";
-		var appDir = "file:///" + Sys.getCwd() + "/";
+		var appDir = #if !linux "file:///" + Sys.getCwd() + "/" #else "file://" + Sys.getCwd() #end;
 
 		if (fileName.indexOf(":") == -1) // Not a path
 			pDir = appDir;
 		else if (fileName.indexOf("file://") == -1 || fileName.indexOf("http") == -1) // C:, D: etc? ..missing "file:///" ?
-			pDir = "file:///";
+			pDir = #if !linux "file:///" #else "file://" #end;
 
 		return pDir + fileName;
 		#else


### PR DESCRIPTION
It doesn't open the video on Linux with the path it's currently given. I made a way to let it open for Linux also! :)