### PR TITLE
Revert volume change

### DIFF
--- a/src/VideoHandler.hx
+++ b/src/VideoHandler.hx
@@ -41,7 +41,7 @@ class VideoHandler extends VLCBitmap {
 		if (FlxG.sound.muted || FlxG.sound.volume <= 0)
 			volume = 0;
 		else if (canUseSound)
-			volume = FlxG.sound.volume;
+			volume = FlxG.sound.volume + 0.4;
 	}
 
 	private function resize(?e:Event):Void {


### PR DESCRIPTION
Reverts a change to how the volume was set, which ended up causing the volume to be significantly quieter.

Before:

https://user-images.githubusercontent.com/15317421/178155691-62ac8628-dafa-4ef7-82e2-4937983a07d2.mp4

After:

https://user-images.githubusercontent.com/15317421/178155697-213ff629-d85c-482a-8860-eda6eb865b23.mp4
