### PR TITLE
Allow video to continue playing if auto pause is disabled

### DIFF
--- a/src/VideoHandler.hx
+++ b/src/VideoHandler.hx
@@ -83,11 +83,13 @@ class VideoHandler extends VLCBitmap {
 		if (FlxG.stage.hasEventListener(Event.RESIZE))
 			FlxG.stage.removeEventListener(Event.RESIZE, resize);
 
-		if (FlxG.signals.focusGained.has(resume))
-			FlxG.signals.focusGained.remove(resume);
+		if (FlxG.autoPause) {
+			if (FlxG.signals.focusGained.has(resume))
+				FlxG.signals.focusGained.remove(resume);
 
-		if (FlxG.signals.focusLost.has(pause))
-			FlxG.signals.focusLost.remove(pause);
+			if (FlxG.signals.focusLost.has(pause))
+				FlxG.signals.focusLost.remove(pause);
+		}
 
 		dispose();
 
@@ -118,8 +120,10 @@ class VideoHandler extends VLCBitmap {
 		FlxG.stage.addEventListener(Event.ENTER_FRAME, update);
 		FlxG.stage.addEventListener(Event.RESIZE, resize);
 
-		FlxG.signals.focusGained.add(resume);
-		FlxG.signals.focusLost.add(pause);
+		if (FlxG.autoPause) {
+			FlxG.signals.focusGained.add(resume);
+			FlxG.signals.focusLost.add(pause);
+		}
 	}
 
 	private function calc(ind:Int):Float {


### PR DESCRIPTION
This allows the video to continue playback if the game loses focus with FlxG.autoPause set to false.

Before:

https://user-images.githubusercontent.com/15317421/178155873-4760744f-09ef-4b6e-8c62-64b3b90d5fa4.mp4

After:

https://user-images.githubusercontent.com/15317421/178155878-34545fd0-5bfa-4ee5-85c2-0ad50fb592b2.mp4
