### PR TITLE
Things

### DIFF
--- a/haxelib.json
+++ b/haxelib.json
@@ -17,11 +17,5 @@
 	"releasenote":"Updated VLC and added support for non-mp4 video formats",
 	"contributors":[
 		"polybiusproxy"
-	],
-	"dependencies":{
-		"flixel":"",
-		"lime":"",
-		"openfl":""
-	},
-	"main":"VideoHandler"
+	]
 }

--- a/lib/vlc/src/LibVLC.cpp
+++ b/lib/vlc/src/LibVLC.cpp
@@ -2,8 +2,6 @@
 #include <iostream>
 #include <string>
 #include <stdint.h>
-using std::string;
-using namespace std;
 
 LibVLC::LibVLC(void)
 {
@@ -185,16 +183,28 @@ float LibVLC::getFPS()
 
 int LibVLC::getWidth()
 {
+	unsigned int width;
+	unsigned int height;
+
 	if (libVlcMediaPlayer != NULL && libVlcMediaPlayer != nullptr)
-		return libvlc_video_get_width(libVlcMediaPlayer);
+	{
+		libvlc_video_get_size(libVlcMediaPlayer, 0, &width, &height);
+		return width;
+	}
 	else
 		return 0;
 }
 
 int LibVLC::getHeight()
 {
+	unsigned int width;
+	unsigned int height;
+
 	if (libVlcMediaPlayer != NULL && libVlcMediaPlayer != nullptr)
-		return libvlc_video_get_height(libVlcMediaPlayer);
+	{
+		libvlc_video_get_size(libVlcMediaPlayer, 0, &width, &height);
+		return height;
+	}
 	else
 		return 0;
 }

--- a/lib/vlc/src/LibVLC.cpp
+++ b/lib/vlc/src/LibVLC.cpp
@@ -1,6 +1,3 @@
-#include <mutex>
-#include <iostream>
-#include <string>
 #include <stdint.h>
 
 LibVLC::LibVLC(void)


### PR DESCRIPTION
* removed unused includes.
* updated haxelib.json to not install the latest version of the respective library for no reason.
* Replaced the deprecated `libvlc_video_get_width` and `libvlc_video_get_height` with `libvlc_video_get_size`

The changes got tested on my Test-Base repo