### PR TITLE
Set volume of the video when first playing it

### DIFF
--- a/src/VideoHandler.hx
+++ b/src/VideoHandler.hx
@@ -31,6 +31,11 @@ class VideoHandler extends VLCBitmap
 		onError = onVLCError;
 
 		FlxG.addChildBelowMouse(this);
+		
+		if ((FlxG.sound.muted || FlxG.sound.volume <= 0) || !canUseSound)
+			volume = 0;
+		else if (canUseSound)
+			volume = FlxG.sound.volume * 100;
 	}
 
 	/**


### PR DESCRIPTION
This used to be in the code pre-rewrite, seems like it was forgotten to be added back.

All this does is makes sure the video doesn't jumpscare you with how loud it is when it first starts because that can happen and has to me plenty of times.