### PR TITLE
Add 'skipKeys'

### DIFF
--- a/src/VideoHandler.hx
+++ b/src/VideoHandler.hx
@@ -1,5 +1,6 @@
 package;
 
+import flixel.input.keyboard.FlxKey;
 import flixel.FlxG;
 import openfl.Lib;
 import openfl.events.Event;
@@ -13,6 +14,8 @@ import vlc.VLCBitmap;
 class VideoHandler extends VLCBitmap
 {
 	public var canSkip:Bool = true;
+	public var skipKeys:Array<FlxKey> = [FlxKey.SPACE];
+
 	public var canUseSound:Bool = true;
 	public var canUseAutoResize:Bool = true;
 
@@ -108,7 +111,7 @@ class VideoHandler extends VLCBitmap
 	private function update(?E:Event):Void
 	{
 		#if FLX_KEYBOARD
-		if (canSkip && (FlxG.keys.justPressed.SPACE #if android || FlxG.android.justReleased.BACK #end) && (isPlaying && isDisplaying))
+		if (canSkip && (FlxG.keys.anyJustPressed(skipKeys) #if android || FlxG.android.justReleased.BACK #end) && (isPlaying && isDisplaying))
 			onVLCEndReached();
 		#elseif android
 		if (canSkip && FlxG.android.justReleased.BACK && (isPlaying && isDisplaying))

--- a/src/VideoSprite.hx
+++ b/src/VideoSprite.hx
@@ -1,5 +1,6 @@
 package;
 
+import flixel.input.keyboard.FlxKey;
 import flixel.FlxG;
 import flixel.FlxSprite;
 import flixel.graphics.FlxGraphic;
@@ -17,6 +18,8 @@ class VideoSprite extends FlxSprite
 
 	public var openingCallback:Void->Void = null;
 	public var finishCallback:Void->Void = null;
+
+	public var skipKeys(get, set):Array<FlxKey>;
 
 	public function new(X:Float = 0, Y:Float = 0)
 	{
@@ -77,4 +80,12 @@ class VideoSprite extends FlxSprite
 	 */
 	public function playVideo(Path:String, Loop:Bool = false, PauseMusic:Bool = false):Void
 		bitmap.playVideo(Path, Loop, PauseMusic);
+
+	@:noCompletion
+	private function get_skipKeys():Array<FlxKey>
+		return bitmap.skipKeys;
+
+	@:noCompletion
+	private function set_skipKeys(Value:Array<FlxKey>):Array<FlxKey>
+		return bitmap.skipKeys = Value;
 }


### PR DESCRIPTION
This PR adds an array of `FlxKeys`, which helps set custom keybinds to skip the video instead of hardcoding it to the space key only.