### PR TITLE
Rendering Overhaul.

### DIFF
--- a/src/hxcodec/vlc/VLCBitmap.hx
+++ b/src/hxcodec/vlc/VLCBitmap.hx
@@ -506,7 +506,7 @@ class VLCBitmap extends Bitmap
 
 		deltaTimeElapsed += deltaTime;
 
-		if (Math.abs(delta - oldTime) < 16)
+		if (Math.abs(deltaTimeElapsed - oldTime) < 16)
 			return;
 		else
 			oldTime = deltaTimeElapsed;


### PR DESCRIPTION
This PR aims to fix rendering performance while improving video framerate - Inspired from hxCodecPlus.

The rendering is now locked at 16ms which is 60 fps video playback.. Here's a list of changes. 

- width ++ has been changed to be initialized with the Texture and Bitmap.
- Removed redundant null checks.
- Use the deltatime from the __enterFrame.
- Inlined the renderVideo function which removes unnecessary calls.
- Removed RenderDirty it did nothing?
- Get the abs of the delta time and return blank frames to improve performance. 
- Added a check for the Bitmap because texture == null kept creating the texture causing the game to use 22% CPU.

This does not solve the haults mid playthrough I'm not sure what causes those on this version of hxcodec my guess is LibVLC.

![image](https://user-images.githubusercontent.com/84131849/236664010-f4ac81f2-2830-4e63-988b-3113af63692f.png)
![image](https://user-images.githubusercontent.com/84131849/236664080-de906083-67ea-4c4f-8812-bbac1cc2e1d1.png)


https://user-images.githubusercontent.com/84131849/236664280-258743ca-225a-43ef-9bc9-401da2b15663.mp4

