### PR TITLE
Fix playing videos on Linux when a project uses linc_luajit

### DIFF
--- a/src/hxcodec/lime/MediaPlayer.hx
+++ b/src/hxcodec/lime/MediaPlayer.hx
@@ -135,12 +135,12 @@ class MediaPlayer
 		Sys.putEnv("VLC_PLUGIN_PATH", Path.directory(Sys.programPath()) + '/plugins');
 		#end
 
-		#if (windows || mac)
-		untyped __cpp__('const char *argv[] = { "--reset-config", "--reset-plugins-cache" }');
-
-		instance = LibVLC.create(2, untyped __cpp__('argv'));
+		#if desktop
+		untyped __cpp__('const char *argv[] = { "--reset-config", "--reset-plugins-cache", "--no-lua" }');
+		instance = LibVLC.create(3, untyped __cpp__('argv'));
 		#else
-		instance = LibVLC.create(0, untyped __cpp__('NULL'));
+		untyped __cpp__('const char *argv[] = { "--no-lua" }');
+		instance = LibVLC.create(1, untyped __cpp__('argv'));
 		#end
 
 		#if HXC_LIBVLC_LOGGING

--- a/src/hxcodec/openfl/Video.hx
+++ b/src/hxcodec/openfl/Video.hx
@@ -177,12 +177,12 @@ class Video extends Bitmap
 		Sys.putEnv("VLC_PLUGIN_PATH", Path.directory(Sys.programPath()) + '/plugins');
 		#end
 
-		#if (windows || mac)
-		untyped __cpp__('const char *argv[] = { "--reset-config", "--reset-plugins-cache" }');
-
-		instance = LibVLC.create(2, untyped __cpp__('argv'));
+		#if desktop
+		untyped __cpp__('const char *argv[] = { "--reset-config", "--reset-plugins-cache", "--no-lua" }');
+		instance = LibVLC.create(3, untyped __cpp__('argv'));
 		#else
-		instance = LibVLC.create(0, untyped __cpp__('NULL'));
+		untyped __cpp__('const char *argv[] = { "--no-lua" }');
+		instance = LibVLC.create(1, untyped __cpp__('argv'));
 		#end
 
 		#if HXC_LIBVLC_LOGGING


### PR DESCRIPTION
If it is intended for videos to crash when playing on Linux in a project using linc_luajit because of conflicts between both libraries copies of lua then it would be fine to close this pull request. Otherwise I think merging this makes sense because Lua isn't usually used in the case of hxCodec.

If you want to keep support then I think adding a parameter to use different libVLC arguments in the constructors of FlxVideo, Video, and MediaPlayer would make sense (I'm just not fully sure how to do that at the moment).