### PR TITLE
Multiple fixes

### DIFF
--- a/src/hxcodec/flixel/FlxVideo.hx
+++ b/src/hxcodec/flixel/FlxVideo.hx
@@ -1,5 +1,6 @@
 package hxcodec.flixel;
 
+#if flixel
 import flixel.FlxG;
 import hxcodec.openfl.Video;
 import openfl.events.Event;
@@ -87,3 +88,4 @@ class FlxVideo extends Video
 		#end
 	}
 }
+#end

--- a/src/hxcodec/flixel/FlxVideoBackdrop.hx
+++ b/src/hxcodec/flixel/FlxVideoBackdrop.hx
@@ -1,10 +1,16 @@
 package hxcodec.flixel;
 
-import sys.FileSystem;
-import hxcodec.openfl.Video;
+#if flixel
+#if (!flixel_addons && macro)
+#error 'Your project must use flixel-addons in order to use this class.'
+#end
+	
 import flixel.FlxG;
 import flixel.util.FlxAxes;
 import flixel.addons.display.FlxBackdrop;
+
+import sys.FileSystem;
+import hxcodec.openfl.Video;
 
 /**
  * This class allows you to play videos as `FlxBackdrop`s.
@@ -124,3 +130,4 @@ class FlxVideoBackdrop extends FlxBackdrop
 		super.destroy();
 	}
 }
+#end

--- a/src/hxcodec/flixel/FlxVideoSprite.hx
+++ b/src/hxcodec/flixel/FlxVideoSprite.hx
@@ -1,10 +1,12 @@
 package hxcodec.flixel;
 
+#if flixel
 import flixel.FlxG;
 import flixel.FlxSprite;
 import flixel.util.FlxColor;
-import hxcodec.openfl.Video;
+
 import sys.FileSystem;
+import hxcodec.openfl.Video;
 
 /**
  * This class allows you to play videos using sprites (FlxSprite).
@@ -89,6 +91,18 @@ class FlxVideoSprite extends FlxSprite
 		super.update(elapsed);
 	}
 
+	override public function kill():Void
+	{
+		pause();
+		super.kill();
+	}
+
+	override public function kill():Void
+	{
+		super.revive();
+		resume();
+	}
+
 	override public function destroy():Void
 	{
 		if (FlxG.autoPause)
@@ -111,3 +125,4 @@ class FlxVideoSprite extends FlxSprite
 		super.destroy();
 	}
 }
+#end

--- a/src/hxcodec/flixel/FlxVideoSprite.hx
+++ b/src/hxcodec/flixel/FlxVideoSprite.hx
@@ -97,7 +97,7 @@ class FlxVideoSprite extends FlxSprite
 		super.kill();
 	}
 
-	override public function kill():Void
+	override public function revive():Void
 	{
 		super.revive();
 		resume();


### PR DESCRIPTION
- Added `flixel` compilation blocks to flixel video classes
- Call `pause` when `kill()`ing and `resume` when `revive()`ing an `FlxVideoSprite` (consistency with `FlxSprite` where it hides the graphic when `kill()`ing it)
- Added a `flixel-addons` compilation block to `FlxVideoBackdrop` (im so sorry for not adding that earlier🙏🙏🙏)